### PR TITLE
Build doesn't work inside a python "venv"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CPPFLAGS += -DNDEBUG -D_REENTRANT					\
 
 
 PY_PYTHON=$(shell python -c "import sys; print(sys.executable)")
-PY_PREFIX=$(shell $(PY_PYTHON) -c "import sys; print(sys.prefix)")
+PY_PREFIX=$(shell $(PY_PYTHON) -c "import sys; print(sys.real_prefix)" || $(PY_PYTHON) -c "import sys; print(sys.prefix)")
 PY_VERSION=$(shell $(PY_PYTHON) -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
 ifeq ($(BUILDOS),Darwin)
 	PY_ARCH=$(shell $(PY_PYTHON) -c 'import sys; print (sys.maxint > 2**32 and "x86_64" or "i386")')


### PR DESCRIPTION
I went to use this on a node.js project, but there are other python things that force the use of "venv," under which apparently `sys.prefix` points at the venv directory, and nothing useful that can be linked against. Under `venv` the thing to use is `sys.real_prefix`, which is (apparently) only present inside a venv. python: demerit.
