### PR TITLE
print warnings to stderr

### DIFF
--- a/javascriptlint/jsl.py
+++ b/javascriptlint/jsl.py
@@ -27,8 +27,8 @@ def _dump(paths):
 def _lint(paths, conf_, printpaths):
     def lint_error(path, line, col, errname, errdesc):
         _lint_results['warnings'] = _lint_results['warnings'] + 1
-        print util.format_error(conf_['output-format'], path, line, col,
-                                      errname, errdesc)
+        print >> sys.stderr, util.format_error(conf_['output-format'],
+                                  path, line, col, errname, errdesc)
     lint.lint_files(paths, lint_error, conf=conf_, printpaths=printpaths)
 
 def _resolve_paths(path, recurse):


### PR DESCRIPTION
@trentm and I were adding git hooks to https://github.com/joyent/node-triton when we came across this.

I want the githooks to be silent in the case where there are no errors, so I had a hook like this

```
#!/usr/bin/env bash
make check test > /dev/null
```

However, it wasn't printing any errors! This change makes all warnings go to stderr